### PR TITLE
Add alternative label for mentor available

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Some of the features of **CLOTributor** are controlled by some special labels (o
 #### Other filters
 
 - `good first issue`: use this label to highlight issues that may be a good fit for new contributors to the project.
-- `mentor available`: to indicate that someone may be available to guide contributors with this issue.
+- `mentor available` or `mentorship`: to indicate that someone may be available to guide contributors with this issue.
 
 ## Projects and repositories
 

--- a/clotributor-tracker/src/tracker.rs
+++ b/clotributor-tracker/src/tracker.rs
@@ -233,7 +233,7 @@ impl Issue {
             }
 
             // Mentor available
-            if label == "mentor available" {
+            if label == "mentor available" || label == "mentorship" {
                 self.mentor_available = Some(true);
                 continue;
             }


### PR DESCRIPTION
In addition to the `mentor available` label, we now also accept `mentorship`.