### PR TITLE
Allow excluding repositories from being processed

### DIFF
--- a/clotributor-registrar/src/registrar.rs
+++ b/clotributor-registrar/src/registrar.rs
@@ -51,6 +51,7 @@ impl Project {
 pub(crate) struct Repository {
     pub name: String,
     pub url: String,
+    pub exclude: Option<Vec<String>>,
 }
 
 /// Defines if the project is looking for maintainers, as well as some extra
@@ -148,6 +149,14 @@ async fn process_foundation(
     let tmp: Vec<Project> = serde_yaml::from_str(&data)?;
     let mut projects_available: HashMap<String, Project> = HashMap::with_capacity(tmp.len());
     for mut project in tmp {
+        // Do not include repositories that have been excluded for this service
+        project.repositories.retain(|r| {
+            if let Some(exclude) = &r.exclude {
+                return !exclude.contains(&"clotributor".to_string());
+            }
+            true
+        });
+
         project.set_digest()?;
         projects_available.insert(project.name.clone(), project);
     }
@@ -337,7 +346,7 @@ mod tests {
                 projects_registered.insert(
                     "artifact-hub".to_string(),
                     Some(
-                        "b0066337ee0887eafc0324e7432e622312b649cfdacaa322dfd433466bc0219c"
+                        "cda91a89489ac52d9160edee5e41828995e9f37832951180d30d7103f5f4f1ee"
                             .to_string(),
                     ),
                 );
@@ -385,10 +394,11 @@ mod tests {
                     devstats_url: Some("https://artifacthub.devstats.cncf.io/".to_string()),
                     accepted_at: Some("2020-06-23".to_string()),
                     maturity: "sandbox".to_string(),
-                    digest: Some("b0066337ee0887eafc0324e7432e622312b649cfdacaa322dfd433466bc0219c".to_string()),
+                    digest: Some("cda91a89489ac52d9160edee5e41828995e9f37832951180d30d7103f5f4f1ee".to_string()),
                     repositories: vec![Repository{
                         name: "artifact-hub".to_string(),
                         url: "https://github.com/artifacthub/hub".to_string(),
+                        exclude: None,
                     }],
                     maintainers_wanted: None,
                 }),
@@ -429,7 +439,7 @@ mod tests {
                 projects_registered.insert(
                     "artifact-hub".to_string(),
                     Some(
-                        "b0066337ee0887eafc0324e7432e622312b649cfdacaa322dfd433466bc0219c"
+                        "cda91a89489ac52d9160edee5e41828995e9f37832951180d30d7103f5f4f1ee"
                             .to_string(),
                     ),
                 );

--- a/clotributor-registrar/src/testdata/cncf.yaml
+++ b/clotributor-registrar/src/testdata/cncf.yaml
@@ -12,3 +12,9 @@
       check_sets:
         - community
         - code
+    - name: blog
+      url: https://github.com/artifacthub/blog
+      check_sets:
+        - docs
+      exclude:
+        - clotributor


### PR DESCRIPTION
Sometimes a project may want a repository to only be processed by one of the services feeding from the data files.

For example, a project may want to have all their repositories processed by CLOTributor, but only a subset of them by CLOMonitor. This new feature make this configurable by using the `exclude` field, which accepts a list of services to exclude the repository from (valid values are `clomonitor` and `clotributor` at the moment).

In this example, we are requesting that the `func` repository is not processed by CLOMonitor:

```yaml
- name: knative
  display_name: Knative
  description: Kubernetes-based platform to build, deploy, and manage modern serverless workloads
  category: serverless
  logo_url: https://raw.githubusercontent.com/cncf/artwork/master/projects/knative/icon/color/knative-icon-color.svg
  devstats_url: https://knative.devstats.cncf.io/
  accepted_at: "2022-03-02"
  maturity: incubating
  repositories:
    - name: docs
      url: https://github.com/knative/docs/
      check_sets:
        - docs
    - name: func
      url: https://github.com/knative/func
      check_sets:
        - code-lite
      exclude:
        - clomonitor
```